### PR TITLE
When signing you don't UrlEncode values. You are going to generate a …

### DIFF
--- a/RememberTheMilkApi/Objects/RtmApiResponse.cs
+++ b/RememberTheMilkApi/Objects/RtmApiResponse.cs
@@ -35,6 +35,9 @@ namespace RememberTheMilkApi.Objects
         [JsonProperty("timeline")]
         public string TimeLine { get; set; }
 
+        [JsonProperty("list")]
+        public RtmApiTaskSeriesList List { get; set; }
+
         public RtmApiResponse()
         {
             Status = string.Empty;
@@ -47,6 +50,7 @@ namespace RememberTheMilkApi.Objects
             ListCollection = new RtmApiListCollection();
             ErrorResponse = new RtmApiErrorResponse();
             TimeLine = string.Empty;
+            List = new RtmApiTaskSeriesList();
         }
     }
 }

--- a/RememberTheMilkApi/Objects/RtmApiResponse.cs
+++ b/RememberTheMilkApi/Objects/RtmApiResponse.cs
@@ -32,6 +32,9 @@ namespace RememberTheMilkApi.Objects
         [JsonProperty("err")]
         public RtmApiErrorResponse ErrorResponse { get; set; }
 
+        [JsonProperty("timeline")]
+        public string TimeLine { get; set; }
+
         public RtmApiResponse()
         {
             Status = string.Empty;
@@ -43,6 +46,7 @@ namespace RememberTheMilkApi.Objects
             TaskSeriesCollection = new RtmApiTaskSeriesCollection();
             ListCollection = new RtmApiListCollection();
             ErrorResponse = new RtmApiErrorResponse();
+            TimeLine = string.Empty;
         }
     }
 }

--- a/RememberTheMilkApi/RtmConnection.cs
+++ b/RememberTheMilkApi/RtmConnection.cs
@@ -109,7 +109,8 @@ namespace RememberTheMilkApi
 
         private static string EncodeParameters(IDictionary<string, string> parameters, bool signing = false)
         {
-            return string.Join(signing ? "" : "&", parameters.Select(kvp => string.Format("{0}{1}{2}", kvp.Key, signing ? "" : "=", HttpUtility.UrlEncode(kvp.Value))));
+            return string.Join(signing ? "" : "&", 
+                parameters.Select(kvp => string.Format("{0}{1}", kvp.Key, signing ? kvp.Value : "=" + HttpUtility.UrlEncode(kvp.Value))));
         }
 
         private static string CalculateMd5Hash(string input)


### PR DESCRIPTION
…MD5Hash and this will fail if there are any encoded parameters.

In my case I call rtm.tasks.getList with a parameter "filter" with value "list:ps-Daily". The : got UrlEncoded and RTM barfed.